### PR TITLE
enable prometheus servicemonitor

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,5 @@ global:
   leaderElection:
     namespace: cert-manager
 prometheus:
-  enabled: true
   servicemonitor:
-    enabled: true
+    enabled: true 

--- a/values.yaml
+++ b/values.yaml
@@ -6,4 +6,4 @@ global:
     namespace: cert-manager
 prometheus:
   servicemonitor:
-    enabled: true 
+    enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -4,3 +4,7 @@ global:
     create: true
   leaderElection:
     namespace: cert-manager
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true


### PR DESCRIPTION
Based on these docs here:

https://github.com/jetstack/cert-manager/tree/v0.14.3/deploy/charts/cert-manager


Parameter | Description | Default
-- | -- | --
**prometheus.enabled** | **Enable Prometheus monitoring** | true
**prometheus.servicemonitor.enabled** | **Enable Prometheus Operator ServiceMonitor monitoring** | false > **true**
prometheus.servicemonitor.namespace | Define namespace where to deploy the ServiceMonitor resource | (namespace where you are deploying)
prometheus.servicemonitor.prometheusInstance | Prometheus Instance definition | default
prometheus.servicemonitor.targetPort | Prometheus scrape port | 9402
prometheus.servicemonitor.path | Prometheus scrape path | /metrics
prometheus.servicemonitor.interval | Prometheus scrape interval | 60s
prometheus.servicemonitor.labels | Add custom labels to ServiceMonitor |  
prometheus.servicemonitor.scrapeTimeout | Prometheus scrape timeout | 30s

just setting prometheus: enabled (default) and prometheus.servicemonitor enabled.

