### PR TITLE
Feature: Vault Metric ClusterIssuer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 	
 	kubectl apply -f secret-vault-issuer-token.yaml
 	kubectl apply -f service-account-vault.yaml
-	kubeclt apply -f cluster-issuer-vault-metric.yaml
+	kubectl apply -f cluster-issuer-vault-metric.yaml
 
 	helm3 upgrade --install --wait $(RELEASE) \
 		--namespace=$(NAMESPACE) \

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ PROD_ZONE ?= us-central1-a
 lint: lint-yaml lint-ci
 
 lint-yaml:
-		@find . -type f -name '*.yml' | xargs yamllint
-		@find . -type f -name '*.yaml' | xargs yamllint
+		find . -type f -name '*.yml' | xargs yamllint
+		find . -type f -name '*.yaml' | xargs yamllint
 
 lint-ci:
-		@circleci config validate
+		circleci config validate
 
 # Helm Initialisation
 init:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RELEASE := cert-manager
 NAMESPACE := cert-manager
 
 CHART_NAME := jetstack/cert-manager
-CHART_VERSION ?= 1.9.1
+CHART_VERSION ?= 1.12.4
 #If changing chart version here, also update create_crds.sh
 #Unless your upgrading to 0.15.x where you can create creds
 #via helm.

--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,11 @@ PROD_ZONE ?= us-central1-a
 
 .DEFAULT_TARGET: status
 
-lint: lint-yaml lint-ci
+lint: lint-yaml
 
 lint-yaml:
 		find . -type f -name '*.yml' | xargs yamllint
 		find . -type f -name '*.yaml' | xargs yamllint
-
-lint-ci:
-		circleci version
-		circleci --help
-		circleci config validate
 
 # Helm Initialisation
 init:

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ lint-yaml:
 		find . -type f -name '*.yaml' | xargs yamllint
 
 lint-ci:
+		circleci version
+		circleci --help
 		circleci config validate
 
 # Helm Initialisation

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ endif
 	./create_crds.sh
 	kubectl apply -f letsencrypt-secret.yaml
 	./create_issuer.sh
+	
+	kubectl apply -f secret-vault-issuer-token.yaml
+	kubectl apply -f service-account-vault.yaml
+	kubeclt apply -f cluster-issuer-vault-metric.yaml
+
 	helm3 upgrade --install --wait $(RELEASE) \
 		--namespace=$(NAMESPACE) \
 		--version $(CHART_VERSION) \
@@ -104,3 +109,5 @@ destroy:
 config-secrets:
 	@echo -n "Appending Thanos Service Account credentials from environment to objstore.yaml"
 	perl -p -i template.pl < ./letsencrypt-secret.yaml.tpl > letsencrypt-secret.yaml
+	@echo -n "Vault Metric CluserIssuer"
+	perl -p -i template.pl < ./cluster-issuer-vault-metric.yaml.tpl > cluster-issuer-vault-metric.yaml

--- a/cluster-issuer-vault-metric.yaml.tpl
+++ b/cluster-issuer-vault-metric.yaml.tpl
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: vault-issuer
+  name: vault-metric
   namespace: cert-manager
 spec:
   vault:

--- a/cluster-issuer-vault-metric.yaml.tpl
+++ b/cluster-issuer-vault-metric.yaml.tpl
@@ -3,7 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: vault-issuer
-  namespace: sandbox
+  namespace: cert-manager
 spec:
   vault:
     path: >-

--- a/cluster-issuer-vault-metric.yaml.tpl
+++ b/cluster-issuer-vault-metric.yaml.tpl
@@ -1,6 +1,6 @@
 ---
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: ClusterIssuer
 metadata:
   name: vault-issuer
   namespace: cert-manager

--- a/cluster-issuer-vault-metric.yaml.tpl
+++ b/cluster-issuer-vault-metric.yaml.tpl
@@ -1,0 +1,22 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: vault-issuer
+  namespace: sandbox
+spec:
+  vault:
+    path: >-
+      ${VAULT_METRIC_PATH}
+    server: >-
+      ${VAULT_ADDRESS}
+    caBundle:  >-
+      ${CA_CRT}
+    auth:
+      kubernetes:
+        role: my-app-1
+        mountPath: /v1/auth/kubernetes
+        secretRef:
+          name: vault-issuer-token
+          key: token
+---

--- a/create_crds.sh
+++ b/create_crds.sh
@@ -5,4 +5,4 @@ set -euo pipefail
 #https://cert-manager.io/docs/installation/kubernetes/#installing-with-helm
 #Kubernetes 1.15+
   kubectl apply --validate=false \
-	 -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.crds.yaml
+	 -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.4/cert-manager.crds.yaml

--- a/secret-vault-issuer-token.yaml
+++ b/secret-vault-issuer-token.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-issuer-token
+  namespace: cert-manager
+  annotations:
+    kubernetes.io/service-account.name: "cert-manager-vault"
+type: kubernetes.io/service-account-token
+data: {}

--- a/service-account-vault.yaml
+++ b/service-account-vault.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager-vault
+  namespace: cert-manager


### PR DESCRIPTION
This PR adds a ClusterIssuer for issuing certs from the Metric Server PKI Engine in Greenpeace's Vault Server. The certificates are used to facilitate mTLS between monitoring components inside the P4 cluster.